### PR TITLE
BatteryMeterView: fix logcat warning spam

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/BatteryMeterView.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryMeterView.java
@@ -433,6 +433,7 @@ public class BatteryMeterView extends LinearLayout implements
                     mBatteryPercentView.setTextAppearance(mPercentageStyleId);
                 }
                 if (mTextColor != 0) mBatteryPercentView.setTextColor(mTextColor);
+                updatePercentText();
                 addView(mBatteryPercentView,
                         new ViewGroup.LayoutParams(
                                 LayoutParams.WRAP_CONTENT,
@@ -451,7 +452,6 @@ public class BatteryMeterView extends LinearLayout implements
             mCircleDrawable.setShowPercent(drawPercentInside);
             mFullCircleDrawable.setShowPercent(drawPercentInside);
         }
-        updatePercentText();
     }
 
     public void setIsQsHeader(boolean isQs) {


### PR DESCRIPTION
* This spam occurs when displaying keyguard.

 2672  2672 W View    : requestLayout() improperly called by android.widget.TextView{8e47ff1 V.ED..... ......ID 0,0-78,105 #7f0a007c app:id/battery_percentage_view} during layout: running second layout pass
 2672  2672 W View    : requestLayout() improperly called by android.widget.TextView{8e47ff1 V.ED..... ......ID 0,0-78,105 #7f0a007c app:id/battery_percentage_view} during second layout pass: posting in next frame

Change-Id: I461b1076103b57c23e4b05de9f2ce9705f3223a0
Signed-off-by: Dmitrii <bankersenator@gmail.com>